### PR TITLE
MessageSecurityMode & SecurityPolicy 

### DIFF
--- a/greengrass-opcua-adapter-nodejs/index.js
+++ b/greengrass-opcua-adapter-nodejs/index.js
@@ -4,6 +4,8 @@ require('requirish')._(module);
 const Subscriber = require('subscriber');
 const opcua = require('node-opcua');
 const IotData = require('aws-greengrass-core-sdk').IotData;
+const MessageSecurityMode = require("node-opcua-service-secure-channel").MessageSecurityMode;
+const SecurityPolicy = require("node-opcua-secure-channel").SecurityPolicy;
 
 const device = new IotData();
 

--- a/greengrass-opcua-adapter-nodejs/package.json
+++ b/greengrass-opcua-adapter-nodejs/package.json
@@ -1,5 +1,7 @@
 {
     "dependencies" : {
-        "node-opcua" : "0.0.64"
+        "node-opcua" : "0.0.64",
+        "node-opcua-secure-channel": "^0.3.0",
+        "node-opcua-service-secure-channel": "^0.3.0"
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
The enums that are used within index.js are actually defined in two external packages (not node-opcua). Without this fix, the code will fail stating MessageSecurityMode & SecurityPolicy are undefined:

> /runtime/nodejs6.10/lambda_nodejs_runtime.js:171
>             throw e;
>             ^
> 
> ReferenceError: MessageSecurityMode is not defined
>     at Object.<anonymous> (/lambda/index.js:32:20)
>     at Module._compile (module.js:652:30)
>     at Object.Module._extensions..js (module.js:663:10)
>     at Module.load (module.js:565:32)
>     at tryModuleLoad (module.js:505:12)
>     at Function.Module._load (module.js:497:3)
>     at Module.require (module.js:596:17)
>     at require (internal/module.js:11:18)
>     at new Runtime (/runtime/nodejs6.10/lambda_nodejs_runtime.js:166:28)
>     at Object.<anonymous> (/runtime/nodejs6.10/lambda_nodejs_runtime.js:366:17)


*Description of changes:*
The relevant packages have been added to package.json, and index.js has been updated to pull in the enums from those packages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
