### PR TITLE
Bump to OPC UA node to 0.7.2

### DIFF
--- a/greengrass-opcua-adapter-nodejs/package.json
+++ b/greengrass-opcua-adapter-nodejs/package.json
@@ -1,5 +1,5 @@
 {
     "dependencies" : {
-        "node-opcua" : "0.0.64"
+        "node-opcua" : "0.7.2"
     }
 }


### PR DESCRIPTION
The current version have 2 years old. Lets bump it to 0.7.2

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
