### PR TITLE
Update node-opcua to 0.0.65

### DIFF
--- a/greengrass-opcua-adapter-nodejs/package.json
+++ b/greengrass-opcua-adapter-nodejs/package.json
@@ -1,5 +1,5 @@
 {
     "dependencies" : {
-        "node-opcua" : "0.0.64"
+        "node-opcua" : "0.0.65"
     }
 }


### PR DESCRIPTION
Hi AWS,

Since we can now use nodejs 8.10 with greengrass, is necessary to bump to 0.0.65. Is the first version of nodejs opc ua supporting version 8 and there is timestamp support!
